### PR TITLE
fix: emit root as a fragement instead of a div if a useFragment property is present

### DIFF
--- a/eleventy-mdx.js
+++ b/eleventy-mdx.js
@@ -137,7 +137,7 @@ class EleventyMDX {
         props = { ...serializeEleventyProps(props), ...props };
       }
 
-      const rootComponent = mdxFragment ? React.createElement(React.Fragment, { id: ROOT_ID }, React.createElement(___mdx_component, props)) : React.createElement("div", { id: ROOT_ID }, React.createElement(___mdx_component, props));
+      const rootComponent = mdxFragment ? React.createElement(React.Fragment, {}, React.createElement(___mdx_component, props)) : React.createElement("div", { id: ROOT_ID }, React.createElement(___mdx_component, props));
 
       if (!serializeEleventyProps) {
         const content = renderToStaticMarkup(rootComponent);

--- a/eleventy-mdx.js
+++ b/eleventy-mdx.js
@@ -115,7 +115,7 @@ class EleventyMDX {
 
       const ROOT_ID = `MDX_ROOT_${process.env.NODE_ENV !== "test" ? uuid() : "test"}`;
 
-      const { ___mdx_component, ___mdx_clientBundle, htmlTemplate, serializeEleventyProps } = await getData(inputPath);
+      const { ___mdx_component, ___mdx_clientBundle, htmlTemplate, serializeEleventyProps, mdxFragment } = await getData(inputPath);
       
       let hydrateScript = "";
       if (serializeEleventyProps) {
@@ -137,7 +137,7 @@ class EleventyMDX {
         props = { ...serializeEleventyProps(props), ...props };
       }
 
-      const rootComponent = React.createElement("div", { id: ROOT_ID }, React.createElement(___mdx_component, props));
+      const rootComponent = mdxFragment ? React.createElement(React.Fragment, { id: ROOT_ID }, React.createElement(___mdx_component, props)) : React.createElement("div", { id: ROOT_ID }, React.createElement(___mdx_component, props));
 
       if (!serializeEleventyProps) {
         const content = renderToStaticMarkup(rootComponent);


### PR DESCRIPTION
This only changes behavior if the user adds a mdxUseFrament prop to the matter.

This allows using mdx as a layout that also emits a <head> section like this:

```
---
title: Super Products - Blah blah blah
mdxFragment: true
---

import HeadComp from "./head.jsx"

<html lang="en">
  <HeadComp {...props} />
  <body dangerouslySetInnerHTML={{ __html: props.content }}></body>
</html>
```
